### PR TITLE
Improve the logic to check/use MX record

### DIFF
--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -8,7 +8,7 @@ module Certman
           domain_validation_options: [
             {
               domain_name: @domain,
-              validation_domain: @domain
+              validation_domain: validation_domain
             }
           ]
         )
@@ -27,7 +27,7 @@ module Certman
         current_cert = acm.list_certificates.certificate_summary_list.find do |cert|
           cert.domain_name == @domain
         end
-        raise 'Certificate already exist' if current_cert
+        current_cert
       end
 
       def acm


### PR DESCRIPTION
Fixes #12 

```sh
$ AWS_PROFILE=xxxxxx AWS_REGION=us-west-2 bundle exec exe/certman request blog.example.com
NOTICE! Your selected region is *us-west-2*. Certman create certificate on *us-west-2*. OK? Yes
NOTICE! When requesting, Certman replace Active Receipt Rule Set. OK? Yes
[✔] [ACM] Check Certificate (us-west-2) (successfull)
[✔] [Route53] Check Hosted Zone (us-west-2) (successfull)
[✔] [Route53] Check TXT Record (us-west-2) (successfull)
[✔] [Route53] Check MX Record (us-west-2) (successfull)
blog.example.com CNAME already exist. Use example.com
[✔] [ACM] Check Certificate (us-west-2) (successfull)
[✔] [Route53] Check Hosted Zone (us-west-2) (successfull)
[✔] [Route53] Check TXT Record (us-west-2) (successfull)
[✔] [Route53] Check MX Record (us-west-2) (successfull)
[✔] [S3] Create Bucket for SES inbound (us-west-2) (successfull)
[✔] [SES] Create Domain Identity (us-west-2) (successfull)
[✔] [Route53] Create TXT Record Set to verify Domain Identity (us-west-2) (successfull)
...
```
