### PR TITLE
--non-interactive and --subject-alternative-names flags 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/AbcSize:
   Max: 160
@@ -21,15 +21,15 @@ Metrics/BlockLength:
 
 Metrics/LineLength:
   Max: 120
-  
+
 Style/Documentation:
   Enabled: false
 
 Style/IndentHeredoc:
   Enabled: false
-  
+
 Style/MutableConstant:
   Enabled: false
-  
+
 Style/PercentLiteralDelimiters:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 160
 
@@ -25,7 +28,7 @@ Metrics/LineLength:
 Style/Documentation:
   Enabled: false
 
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false
 
 Style/MutableConstant:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
+  - 2.4.2
+  - 2.3.5
 before_install:
-  - gem install bundler -v 1.12.5
+  - gem install bundler -v 1.16
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.4.2
   - 2.3.5
+  - 2.2.8
 before_install:
   - gem install bundler -v 1.16
 script:

--- a/README.md
+++ b/README.md
@@ -28,45 +28,64 @@ $ gem install certman
 
 ```sh
 $ certman request blog.example.com
-NOTICE! Your selected region is *ap-northeast-1*. Certman create certificate on *ap-northeast-1*. OK? Yes
-NOTICE! Certman use *us-east-1* S3/SES. OK? Yes
-NOTICE! When requesting, Certman replace Active Receipt Rule Set. OK? Yes
-[✔] [ACM] Check Certificate (ap-northeast-1) (successfull)
-[✔] [Route53] Check Hosted Zone (ap-northeast-1) (successfull)
-[✔] [Route53] Check TXT Record (ap-northeast-1) (successfull)
-[✔] [Route53] Check MX Record (ap-northeast-1) (successfull)
-[✔] [S3] Create Bucket for SES inbound (us-east-1) (successfull)
-[✔] [SES] Create Domain Identity (us-east-1) (successfull)
-[✔] [Route53] Create TXT Record Set to verify Domain Identity (ap-northeast-1) (successfull)
-[✔] [SES] Check Domain Identity Status *verified* (us-east-1) (successfull)
-[✔] [Route53] Create MX Record Set (ap-northeast-1) (successfull)
-[✔] [SES] Create Receipt Rule Set (us-east-1) (successfull)
-[✔] [SES] Create Receipt Rule (us-east-1) (successfull)
-[✔] [SES] Replace Active Receipt Rule Set (us-east-1) (successfull)
-[✔] [ACM] Request Certificate (ap-northeast-1) (successfull)
-[✔] [S3] Check approval mail (will take about 30 min) (us-east-1) (successfull)
-[✔] [SES] Revert Active Receipt Rule Set (us-east-1) (successfull)
-[✔] [SES] Delete Receipt Rule (us-east-1) (successfull)
-[✔] [SES] Delete Receipt Rule Set (us-east-1) (successfull)
-[✔] [Route53] Delete MX Record Set (ap-northeast-1) (successfull)
-[✔] [Route53] Delete TXT Record Set (ap-northeast-1) (successfull)
-[✔] [SES] Delete Verified Domain Identiry (us-east-1) (successfull)
-[✔] [S3] Delete Bucket (us-east-1) (successfull)
+NOTICE! Your selected region is *ap-northeast-1*. Certman will create a certificate on *ap-northeast-1*. OK? Yes
+NOTICE! Certman has chosen *us-east-1*  for S3/SES resources. OK? Yes
+NOTICE! When requesting, Certman appends a Receipt Rule to the current Active Receipt Rule Set. OK? Yes
+[✔] [ACM] Check Certificate (us-east-1) (successful)
+[✔] [Route53] Check Hosted Zone (us-east-1) (successful)
+[✔] [Route53] Check TXT Record (us-east-1) (successful)
+[✔] [Route53] Check MX Record (us-east-1) (successful)
+[✔] [SES] Check Active Rule Set (us-east-1) (successful)
+[✔] [S3] Create Bucket for SES inbound (us-east-1) (successful)
+[✔] [SES] Create Domain Identity (us-east-1) (successful)
+[✔] [Route53] Create TXT Record Set to verify Domain Identity (us-east-1) (successful)
+[✔] [SES] Check Domain Identity Status *verified* (us-east-1) (successful)
+[✔] [Route53] Create MX Record Set (us-east-1) (successful)
+[✔] [SES] Create and Active Receipt Rule Set (us-east-1) (successful)
+[✔] [SES] Create Receipt Rule (us-east-1) (successful)
+[✔] [ACM] Request Certificate (us-east-1) (successful)
+[✔] [S3] Check approval mail (will take about 30 min) (us-east-1) (successful)
+[✔] [SES] Delete Receipt Rule (us-east-1) (successful)
+[✔] [SES] Delete Receipt Rule Set (us-east-1) (successful)
+[✔] [Route53] Delete MX Record Set (us-east-1) (successful)
+[✔] [Route53] Delete TXT Record Set (us-east-1) (successful)
+[✔] [SES] Delete Verified Domain Identiry (us-east-1) (successful)
+[✔] [S3] Delete Bucket (us-east-1) (successful)
 Done.
 
 certificate_arn: arn:aws:acm:ap-northeast-1:0123456789:certificate/123abcd4-5e67-8f90-123a-4567bc89d01
-
 ```
 
-#### Remain Resources
+OR
 
-If you want to remain resources, use `--remain-resources` option.
+```sh
+NOTICE! Your selected region is *us-east-1*. Certman will create a certificate on *us-east-1*.
+NOTICE! Certman has chosen *us-east-1* for S3/SES resources.
+NOTICE! When requesting, Certman appends a Receipt Rule to the current Active Receipt Rule Set.
+[✖] [ACM] Check Certificate (us-east-1) (error)
 
-(see http://docs.aws.amazon.com/ja_jp/acm/latest/userguide/managed-renewal.html#how-manual-domain-validation-works)
+Certificate already exists!
+
+certificate_arn: arn:aws:acm:us-east-1:0123456789:certificate/123abcd4-5e67-8f90-123a-4567bc89d01
+```
+
+#### Flags
+
+##### `--remain-resources`
+Skips deleting resources after a certificate has been successfully generated. This is necessary if you cannot use automatic validation (i.e., if your site is not accessible to the public internet via HTTPS). See [How Manual Domain Validation Works](http://docs.aws.amazon.com/acm/latest/userguide/how-domain-validation-works.html) for more information.
+
+##### `--non-interactive`
+Suppresses prompts from Certman (i.e, if using with a CI system, such as Travis or Jenkins).
+
+##### `--subject-alternative-names=www.test.example.com cert.test.example.com`
+Other domain names (separated by spaces) to associate with the requested certificate. Note that only the primary domain name is used for identification purposes and that AWS initially limits each certifcate to 10 SANs.
+
+##### `--hosted-zone=test.example.com`
+Specify the name (not the ID) of the Route53 Hosted Zone where the DNS record sets Certman uses will be located. By default, Certman will use the apex domain (i.e. "test.example.com" will have a default hosted-zone of "example.com").
 
 ### Restore Resources
 
-If you want to restore resources for ACM ( to receive approval mail ), use `certman restore-resources`.
+If you want to restore resources generated for an ACM certificate (i.e., in order to receive approval mail again, use `certman restore-resources`. This supports the `--non-interactive` and `--hosted-zone` flags from `certman request`.
 
 ```sh
 $ certman restore-resources blog.example.com
@@ -76,7 +95,7 @@ $ certman restore-resources blog.example.com
 
 ```sh
 $ certman delete blog.example.com
-[✔] [ACM] Delete Certificate (successfull)
+[✔] [ACM] Delete Certificate (successful)
 Done.
 
 ```

--- a/certman.gemspec
+++ b/certman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
   spec.add_runtime_dependency 'aws-sdk', '< 2.9'
   spec.add_runtime_dependency 'awsecrets', '~> 1.8'
   spec.add_runtime_dependency 'thor'

--- a/certman.gemspec
+++ b/certman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.2'
   spec.add_runtime_dependency 'aws-sdk', '< 2.9'
   spec.add_runtime_dependency 'awsecrets', '~> 1.8'
   spec.add_runtime_dependency 'thor'

--- a/lib/certman/cli.rb
+++ b/lib/certman/cli.rb
@@ -3,22 +3,16 @@ module Certman
     desc 'request [DOMAIN]', 'Request ACM Certificate with only AWS managed services'
     option :remain_resources, type: :boolean, default: false
     option :hosted_zone, type: :string, banner: '<Route53 HostedZone>'
+    option :non_interactive, type: :boolean, default: false
     option :subject_alternative_names, type: :array, banner: 'alt_domain_1 alt_domain_2...'
     def request(domain)
-      pastel = Pastel.new
       prompt = TTY::Prompt.new
-      return unless prompt.yes?(pastel.red("NOTICE! Your selected region is *#{Aws.config[:region]}*. \
-Certman create certificate on *#{Aws.config[:region]}*. OK?"))
+      pastel = Pastel.new
       client = Certman::Client.new(domain, options)
-      return unless prompt.yes?(pastel.red("NOTICE! Certman use *#{client.region_by_hash}* S3/SES. OK?"))
-      return unless prompt.yes?(pastel.red("NOTICE! When requesting, Certman apend Receipt Rule to current Active \
-Receipt Rule Set. OK?"))
-      Signal.trap(:INT) do
-        puts ''
-        puts pastel.red('Rollback start.')
-        client.rollback
-      end
+      prompt_or_notify(client, prompt, pastel)
+      rollback_on_interrupt(client, pastel)
       cert_arn = client.request
+
       puts 'Done.'
       puts ''
       puts "certificate_arn: #{pastel.cyan(cert_arn)}"
@@ -27,21 +21,15 @@ Receipt Rule Set. OK?"))
 
     desc 'restore-resources [DOMAIN]', 'Restore resources to receive approval mail'
     option :hosted_zone, type: :string, banner: '<Route53 HostedZone>'
+    option :non_interactive, type: :boolean, default: false
     def restore_resources(domain)
-      pastel = Pastel.new
       prompt = TTY::Prompt.new
-      return unless prompt.yes?(pastel.red("NOTICE! Your selected region is *#{Aws.config[:region]}*. \
-Certman create certificate on *#{Aws.config[:region]}*. OK?"))
+      pastel = Pastel.new
       client = Certman::Client.new(domain, options)
-      return unless prompt.yes?(pastel.red("NOTICE! Certman use *#{client.region_by_hash}* S3/SES. OK?"))
-      return unless prompt.yes?(pastel.red("NOTICE! When requesting, Certman apend Receipt Rule to current Active \
-Receipt Rule Set. OK?"))
-      Signal.trap(:INT) do
-        puts ''
-        puts pastel.red('Rollback start.')
-        client.rollback
-      end
+      prompt_or_notify(client, prompt, pastel)
+      rollback_on_interrupt(client, pastel)
       client.restore_resources
+
       puts 'Done.'
       puts ''
     end
@@ -49,8 +37,36 @@ Receipt Rule Set. OK?"))
     desc 'delete [DOMAIN]', 'Delete ACM Certificate'
     def delete(domain)
       Certman::Client.new(domain, options).delete
+
       puts 'Done.'
       puts ''
+    end
+
+    private
+
+    def prompt_or_notify(client, prompt, pastel)
+      notices = [
+        "NOTICE! Your selected region is *#{Aws.config[:region]}*. " \
+          "Certman will create a certificate on *#{Aws.config[:region]}*.",
+        "NOTICE! Certman has chosen *#{client.region_by_hash}* for S3/SES resources.",
+        'NOTICE! When requesting, Certman appends a Receipt Rule to the current Active Receipt Rule Set.'
+      ]
+
+      notices.each do |message|
+        if options[:non_interactive]
+          puts pastel.red(message)
+        else
+          exit unless prompt.yes?(pastel.red(message << ' OK?'))
+        end
+      end
+    end
+
+    def rollback_on_interrupt(client, pastel)
+      Signal.trap(:INT) do
+        puts ''
+        puts pastel.red('Rollback start.')
+        client.rollback
+      end
     end
   end
 end

--- a/lib/certman/cli.rb
+++ b/lib/certman/cli.rb
@@ -3,6 +3,7 @@ module Certman
     desc 'request [DOMAIN]', 'Request ACM Certificate with only AWS managed services'
     option :remain_resources, type: :boolean, default: false
     option :hosted_zone, type: :string, banner: '<Route53 HostedZone>'
+    option :subject_alternative_names, type: :array, banner: 'alt_domain_1 alt_domain_2...'
     def request(domain)
       pastel = Pastel.new
       prompt = TTY::Prompt.new

--- a/lib/certman/cli.rb
+++ b/lib/certman/cli.rb
@@ -1,10 +1,10 @@
 module Certman
   class CLI < Thor
-    desc 'request [DOMAIN]', 'Request ACM Certificate with only AWS managed services'
+    desc 'request [DOMAIN]', 'Requests an ACM Certificate with only AWS managed services'
     option :remain_resources, type: :boolean, default: false
-    option :hosted_zone, type: :string, banner: '<Route53 HostedZone>'
     option :non_interactive, type: :boolean, default: false
     option :subject_alternative_names, type: :array, banner: 'alt_domain_1 alt_domain_2...'
+    option :hosted_zone, type: :string, banner: '<Route53 HostedZone Name>'
     def request(domain)
       prompt = TTY::Prompt.new
       pastel = Pastel.new
@@ -20,8 +20,8 @@ module Certman
     end
 
     desc 'restore-resources [DOMAIN]', 'Restore resources to receive approval mail'
-    option :hosted_zone, type: :string, banner: '<Route53 HostedZone>'
     option :non_interactive, type: :boolean, default: false
+    option :hosted_zone, type: :string, banner: '<Route53 HostedZone Name>'
     def restore_resources(domain)
       prompt = TTY::Prompt.new
       pastel = Pastel.new

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -15,7 +15,7 @@ module Certman
       @savepoint = []
       @remain_resources = options[:remain_resources]
       @hosted_zone_domain = options[:hosted_zone]
-      @hosted_zone_domain&.sub(/\.\z/, '')
+      @hosted_zone_domain.sub(/\.\z/, '') if @hosted_zone_domain
     end
 
     def request

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -15,7 +15,7 @@ module Certman
       @savepoint = []
       @remain_resources = options[:remain_resources]
       @hosted_zone_domain = options[:hosted_zone]
-      @hosted_zone_domain.sub(/\.\z/, '') unless @hosted_zone_domain.nil?
+      @hosted_zone_domain&.sub(/\.\z/, '')
     end
 
     def request

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -110,6 +110,11 @@ module Certman
 
     def delete
       s = spinner('[ACM] Delete Certificate')
+      unless certificate_exist?
+        s.error
+        puts pastel.yellow("\nNo certificate to delete!\n")
+        exit
+      end
       delete_certificate
       s.success
     end
@@ -242,10 +247,7 @@ module Certman
           end
         when :acm_certificate
           if @do_rollback
-            s = spinner('[ACM] Delete Certificate')
-            delete_certificate
-            @cert_arn = nil
-            s.success
+            delete # certificate
           end
         end
       end

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -10,6 +10,7 @@ module Certman
       @do_rollback = false
       @cname_exists = false
       @domain = domain
+      @subject_alternative_names = options[:subject_alternative_names]
       @cert_arn = nil
       @savepoint = []
       @remain_resources = options[:remain_resources]

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -59,7 +59,7 @@ module Certman
       end
 
       enforce_region_by_hash do
-        step('[S3] Check approval mail (will take about 30 min)', nil) do
+        step('[S3] Check for approval mail (can take up to 30 min)', nil) do
           check_approval_mail
         end
       end

--- a/lib/certman/client.rb
+++ b/lib/certman/client.rb
@@ -119,23 +119,40 @@ module Certman
 
       if check_acm
         s = spinner('[ACM] Check Certificate')
-        raise 'Certificate already exist' if certificate_exist?
+        if certificate_exist?
+          s.error
+          puts pastel.yellow("\nCertificate already exists!\n")
+          puts "certificate_arn: #{pastel.cyan(@cert_arn)}"
+          exit
+        end
         s.success
       end
 
       s = spinner('[Route53] Check Hosted Zone')
-      raise "Hosted Zone #{hosted_zone_domain} does not exist" unless hosted_zone_exist?
+      unless hosted_zone_exist?
+        s.error
+        puts pastel.red("\nHosted Zone #{hosted_zone_domain} does not exist")
+        exit
+      end
       s.success
 
       s = spinner('[Route53] Check TXT Record')
-      raise "_amazonses.#{email_domain} TXT already exist" if txt_rset_exist?
+      if txt_rset_exist?
+        s.error
+        puts pastel.red("\n_amazonses.#{email_domain} TXT already exists")
+        exit
+      end
       s.success
 
       enforce_region_by_hash do
         s = spinner('[Route53] Check MX Record')
-        raise "#{email_domain} MX already exist" if mx_rset_exist?
+        if mx_rset_exist?
+          s.error
+          puts pastel.red("\n#{email_domain} MX already exist")
+          exit
+        end
         if cname_rset_exist?
-          puts pastel.cyan("\n#{email_domain} CNAME already exist. Use #{hosted_zone_domain}")
+          puts pastel.cyan("\n#{email_domain} CNAME already exists. Use #{hosted_zone_domain}")
           @cname_exists = true
           check_resource
         end

--- a/lib/certman/log.rb
+++ b/lib/certman/log.rb
@@ -7,7 +7,7 @@ module Certman
     end
 
     def success
-      @s.success(@pastel.green('(successfull)'))
+      @s.success(@pastel.green('(successful)'))
     end
 
     def error

--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -35,7 +35,7 @@ module Certman
         current_cert = acm.list_certificates.certificate_summary_list.find do |cert|
           cert.domain_name == @domain
         end
-        @cert_arn = current_cert.certificate_arn
+        @cert_arn = current_cert&.certificate_arn
       end
 
       def acm

--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -32,7 +32,7 @@ module Certman
         current_cert = acm.list_certificates.certificate_summary_list.find do |cert|
           cert.domain_name == @domain
         end
-        @cert_arn = current_cert&.certificate_arn
+        @cert_arn = current_cert.certificate_arn if current_cert
       end
 
       def acm

--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -35,7 +35,7 @@ module Certman
         current_cert = acm.list_certificates.certificate_summary_list.find do |cert|
           cert.domain_name == @domain
         end
-        current_cert
+        @cert_arn = current_cert.certificate_arn
       end
 
       def acm

--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -4,7 +4,7 @@ module Certman
       def request_certificate
         res = acm.request_certificate(
           domain_name: @domain,
-          subject_alternative_names: [@domain],
+          subject_alternative_names: @subject_alternative_names,
           domain_validation_options: [
             {
               domain_name: @domain,

--- a/lib/certman/resource/acm.rb
+++ b/lib/certman/resource/acm.rb
@@ -24,11 +24,8 @@ module Certman
       end
 
       def delete_certificate
-        current_cert = acm.list_certificates.certificate_summary_list.find do |cert|
-          cert.domain_name == @domain
-        end
-        raise 'Certificate does not exist' unless current_cert
-        acm.delete_certificate(certificate_arn: current_cert.certificate_arn)
+        acm.delete_certificate(certificate_arn: @cert_arn)
+        @cert_arn = nil
       end
 
       def certificate_exist?


### PR DESCRIPTION
Hello!

I'm looking to use certman in a CI setup to help automate the deployment of dozens of sites at once, but needed to make a few changes for that to be possible:

1) I'm generally using the www subdomain to redirect, but I want to use the same certificate for both domain names to make administration easier so I needed to add a `--subject-alternative-names=domain1 domain2` flag.
2) I needed to add a `--non-interactive` flag so it could be run without prompts
3) If a cert already exists, I didn't want my pipeline to completely fail so now certman returns the ARN for an existing cert (and added similar more graceful  exits for the other raise conditions)
4) Did a spelling/grammar pass through to hopefully make the documentation and logging more clear

Hopefully these commits are helpful! Certman is a huge help and automates a very tedious process for me.